### PR TITLE
Replace cpp new with malloc call

### DIFF
--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -30,6 +30,7 @@ with Einfo;                 use Einfo;
 with Atree;                 use Atree;
 with Uintp;                 use Uintp;
 
+with Follow;                use Follow;
 with Ireps;                 use Ireps;
 with Symbol_Table_Info;     use Symbol_Table_Info;
 
@@ -50,6 +51,8 @@ package body Driver is
    procedure Translate_Standard_Types;
    procedure Initialize_CProver_Internal_Variables (Start_Body : Irep);
    procedure Add_CProver_Internal_Symbols;
+   procedure Follow_Type_Declarations (Old_Table : Symbol_Table;
+                                       New_Table : in out Symbol_Table);
 
    procedure GNAT_To_Goto (GNAT_Root : Node_Id)
    is
@@ -107,6 +110,8 @@ package body Driver is
       Base_Name  : constant String :=
         File_Name_Without_Suffix
           (Get_Name_String (Unit_File_Name (Main_Unit)));
+
+      Followed_Symbol_Table : Symbol_Table;
    begin
       Create (Sym_Tab_File, Out_File, Base_Name & ".json_symtab");
       --  Gather local symbols and put them in the symtab
@@ -236,6 +241,8 @@ package body Driver is
          Start_Symbol.BaseName   := Start_Name;
 
          Set_Return_Type (Start_Type, Void_Type);
+         Global_Symbol_Table.Insert (Start_Name, Start_Symbol);
+         Follow_Type_Declarations (Global_Symbol_Table, Followed_Symbol_Table);
 
          Start_Symbol.SymType := Start_Type;
          Start_Symbol.Value   := Start_Body;
@@ -244,7 +251,7 @@ package body Driver is
          Global_Symbol_Table.Insert (Start_Name, Start_Symbol);
 
          Put_Line (Sym_Tab_File,
-                   Create (SymbolTable2Json (Global_Symbol_Table)).Write);
+                   Create (SymbolTable2Json (Followed_Symbol_Table)).Write);
       end if;
 
       Close (Sym_Tab_File);
@@ -376,4 +383,34 @@ package body Driver is
       Add_Global_Sym (Intern ("__CPROVER_rounding_mode"), Int_32_T);
    end Add_CProver_Internal_Symbols;
 
+   procedure Follow_Type_Declarations (Old_Table : Symbol_Table;
+                                       New_Table : in out Symbol_Table) is
+      function Follow_Symbol (I : Irep) return Irep;
+      function Follow_Symbol (I : Irep) return Irep is
+      begin
+         return Follow_Symbol_Type (I, Old_Table);
+      end Follow_Symbol;
+   begin
+      for Sym_Iter in Old_Table.Iterate loop
+         declare
+            Unused_Inserted : Boolean;
+            Unused_Position  : Symbol_Maps.Cursor;
+            Current_Symbol : constant Symbol := Old_Table (Sym_Iter);
+            Modified_Symbol : Symbol := Current_Symbol;
+            SymType : constant Irep := Current_Symbol.SymType;
+            Value : constant Irep := Current_Symbol.Value;
+         begin
+            Modified_Symbol.SymType :=
+                    Follow_Irep (SymType, Follow_Symbol'Access);
+            Modified_Symbol.Value :=
+                    Follow_Irep (Value, Follow_Symbol'Access);
+
+            New_Table.Insert
+                 (Key      => Symbol_Maps.Key (Sym_Iter),
+                  New_Item => Modified_Symbol,
+                  Inserted => Unused_Inserted,
+                  Position => Unused_Position);
+         end;
+      end loop;
+   end Follow_Type_Declarations;
 end Driver;

--- a/gnat2goto/driver/driver.adb
+++ b/gnat2goto/driver/driver.adb
@@ -241,15 +241,13 @@ package body Driver is
          Start_Symbol.BaseName   := Start_Name;
 
          Set_Return_Type (Start_Type, Void_Type);
-         Global_Symbol_Table.Insert (Start_Name, Start_Symbol);
-         Follow_Type_Declarations (Global_Symbol_Table, Followed_Symbol_Table);
 
          Start_Symbol.SymType := Start_Type;
          Start_Symbol.Value   := Start_Body;
          Start_Symbol.Mode    := Intern ("C");
 
          Global_Symbol_Table.Insert (Start_Name, Start_Symbol);
-
+         Follow_Type_Declarations (Global_Symbol_Table, Followed_Symbol_Table);
          Put_Line (Sym_Tab_File,
                    Create (SymbolTable2Json (Followed_Symbol_Table)).Write);
       end if;

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -22,6 +22,8 @@ with Urealp; use Urealp;
 
 package body Tree_Walk is
 
+   function Make_Malloc_Function_Call (Size : Irep) return Irep;
+
    procedure Add_Entity_Substitution (E : Entity_Id; Subst : Irep);
 
    procedure Append_Declare_And_Init
@@ -352,6 +354,21 @@ package body Tree_Walk is
    function Report_Unhandled_Node_Kind (N : Node_Id;
                                         Fun_Name : String;
                                         Message : String) return Irep_Kind;
+
+   function Make_Malloc_Function_Call (Size : Irep) return Irep is
+      Func_Type : constant Irep :=
+        New_Irep (I_Code_Function_Call);
+      Sym_Malloc   : constant Irep := New_Irep (I_Symbol_Expr);
+      Malloc_Args  : constant Irep := New_Irep (I_Argument_List);
+   begin
+      Set_Identifier (Sym_Malloc, "malloc");
+      Set_Type (Sym_Malloc, New_Irep (I_Code_Type));
+      Append_Argument (Malloc_Args, Size);
+      Set_Function        (Func_Type, Sym_Malloc);
+      Set_Arguments       (Func_Type, Malloc_Args);
+      Set_Type            (Func_Type, Make_Pointer_Type (Make_Void_Type));
+      return Func_Type;
+   end Make_Malloc_Function_Call;
 
    procedure Report_Unhandled_Node_Empty (N : Node_Id;
                                           Fun_Name : String;
@@ -3851,8 +3868,6 @@ package body Tree_Walk is
          Alloc_Name : constant String := "__new_array";
          Array_Copy : constant Irep :=
            Fresh_Var_Symbol_Expr (Ptr_Type, "new_array");
-         Array_Alloc : constant Irep :=
-           New_Irep (I_Side_Effect_Expr_Cpp_New_Array);
          Body_Block : constant Irep := New_Irep (I_Code_Block);
          Call_Inst : constant Irep := New_Irep (I_Code_Function_Call);
          Call_Args : constant Irep := New_Irep (I_Argument_List);
@@ -3860,7 +3875,13 @@ package body Tree_Walk is
          Lhs_fun_call : constant Irep :=
            Fresh_Var_Symbol_Expr (Do_Type_Reference (Element_Type),
                                   "array_dup_fun_lhs");
-
+         --  --------------------------------------------------
+         --  NEW VARS FOR MALLOC ALLOCATION
+         Type_Width : constant Integer :=
+           Positive (UI_To_Int (Esize (Element_Type)));
+         Member_Size : constant Irep :=
+           (Make_Integer_Constant (Type_Width, Index_Type));
+         --  --------------------------------------------------
       begin
 
          --  Create type (element_type*, index_type) -> element_type*
@@ -3876,9 +3897,31 @@ package body Tree_Walk is
          Set_Return_Type (Func_Type, Ptr_Type);
 
          --  Create body (allocate and then call array_copy)
-         Set_Size (Array_Alloc, Param_Symbol (Len_Arg));
-         Set_Type (Array_Alloc, Ptr_Type);
-         Append_Declare_And_Init (Array_Copy, Array_Alloc, Body_Block, 0);
+         --  --------------------------------------------------
+         --  NB THIS WORKS IN C, NOT IN C++: 'int *a = malloc(sizeof(int));'
+         Append_Declare_And_Init (Array_Copy,
+                          Make_Malloc_Function_Call (
+                            Make_Op_Mul (
+                              Lhs => Member_Size,
+                              Rhs => Param_Symbol (Len_Arg),
+                              I_Type => Make_Integer_Type,
+                              Source_Location => Sloc (Element_Type))),
+                                  Body_Block, 0);
+         --  --------------------------------------------------
+         --  TYPECAST VERSION
+         --  Append_Declare_And_Init (
+         --    Array_Copy,
+         --    Make_Op_Typecast (
+         --      Op0 =>  Make_Malloc_Function_Call (
+         --        Make_Op_Mul (
+         --          Lhs => Member_Size,
+         --          Rhs => Param_Symbol (Len_Arg),
+         --          I_Type => Make_Integer_Type,
+         --          Source_Location => Sloc (Element_Type))),
+         --          I_Type => Ptr_Type,
+         --      Source_Location => Sloc ((Element_Type))),
+         --    Body_Block, 0);
+         --  --------------------------------------------------
          Append_Argument (Call_Args, Array_Copy);
          Append_Argument (Call_Args, Param_Symbol (Ptr_Arg));
          Append_Argument (Call_Args, Param_Symbol (Len_Arg));

--- a/gnat2goto/driver/tree_walk.adb
+++ b/gnat2goto/driver/tree_walk.adb
@@ -1836,6 +1836,8 @@ package body Tree_Walk is
          when E_Record_Subtype => Do_Itype_Record_Subtype (N),
          when E_Signed_Integer_Type => Do_Itype_Integer_Type (N),
          when E_Floating_Point_Type => Create_Dummy_Irep,
+         when E_Anonymous_Access_Type => Make_Pointer_Type
+        (Base => Do_Type_Reference (Designated_Type (Etype (N)))),
          when others => Report_Unhandled_Node_Irep (N, "Do_Itype_Definition",
                                                     "Unknown Ekind"));
    end Do_Itype_Definition;

--- a/gnat2goto/ireps/follow.adb
+++ b/gnat2goto/ireps/follow.adb
@@ -2,7 +2,7 @@ package body Follow is
    function Follow_Symbol_Type (I : Irep; ST : Symbol_Table) return Irep is
       Next : Irep := I;
    begin
-      while Kind (Next) = I_Symbol_Type loop
+      while Next /= 0 and then Kind (Next) = I_Symbol_Type loop
          Next := ST (Intern (Get_Identifier (Next))).SymType;
       end loop;
       return Next;

--- a/gnat2goto/ireps/ireps-follow_irep.adb
+++ b/gnat2goto/ireps/ireps-follow_irep.adb
@@ -1,0 +1,21 @@
+separate (Ireps)
+function Follow_Irep (L : Irep_List;
+                     Follow_Symbol : not null access function (Symbol_I : Irep)
+                        return Irep) return Irep_List
+is
+   The_List : Irep_List_Node;
+   Ptr      : Internal_Irep_List;
+begin
+   return Arr : constant Irep_List := New_List do
+      if L /= 0 then
+         The_List := Irep_List_Table.Table (To_Internal_List (L));
+         Ptr      := To_Internal_List (Irep_List (The_List.A));
+         while Ptr /= 0 loop
+            Append (Arr,
+                    Follow_Irep (Irep (Irep_List_Table.Table (Ptr).A),
+                                 Follow_Symbol));
+            Ptr := Irep_List_Table.Table (Ptr).B;
+         end loop;
+      end if;
+   end return;
+end Follow_Irep;

--- a/gnat2goto/ireps/ireps_generator.py
+++ b/gnat2goto/ireps/ireps_generator.py
@@ -349,6 +349,25 @@ class IrepsGenerator(object):
             write(b, "end if;")
         return needs_null
 
+    def follow_irep_set_all_subs(self, b, sn, subs, i, needs_null):
+        needs_null = False
+        setter_name, is_list = subs[i]
+        layout_kind, layout_index, layout_typ =\
+            self.layout[sn][setter_name]
+        tbl_index = ada_component_name(layout_kind,
+                                       layout_index)
+        tbl_field = "N." + tbl_index
+        if is_list:
+            assert len(subs) == 1
+            write(b, "Irep_Table.Table (I).%s :=" % tbl_index)
+            with indent(b):
+                write(b, "Integer (Follow_Irep (Irep_List (%s), Follow_Symbol));" % tbl_field)
+        else:
+            write(b, "Irep_Table.Table (I).%s :=" % tbl_index)
+            with indent(b):
+                write(b, "Integer (Follow_Irep (Irep (%s), Follow_Symbol));" % tbl_field)
+        return needs_null
+
     def to_json_set_all_namedsubs_and_comments(self, b, sn, setter_name, needs_null):
         for kind in self.named_setters[setter_name]:
             assert kind in ("irep", "list", "trivial")
@@ -384,6 +403,27 @@ class IrepsGenerator(object):
                 write(b, tmp + '"' + key_name + '",')
                 write(b, " " * len(tmp) + val + ");")
                 continuation(b)
+        return needs_null
+
+    def follow_irep_set_all_namedsubs_and_comments(self, b, sn, setter_name, needs_null):
+        needs_null = True
+        for kind in self.named_setters[setter_name]:
+            assert kind in ("irep", "list", "trivial")
+            if sn in self.named_setters[setter_name][kind]:
+                is_comment, _, _ =\
+                    self.named_setters[setter_name][kind][sn]
+                layout_kind, layout_index, layout_typ =\
+                    self.layout[sn][setter_name]
+                tbl_index = ada_component_name(layout_kind,
+                                               layout_index)
+                tbl_field = "N." + tbl_index
+
+                obj = "Comment" if is_comment else "Named_Sub"
+                if kind == "irep":
+                    write(b, "Irep_Table.Table (I).%s :=" % tbl_index)
+                    with indent(b):
+                        write(b, "Integer (Follow_Irep (Irep (%s), Follow_Symbol));" % tbl_field)
+                    needs_null = False
         return needs_null
 
     def to_json_set_all_constants(self, b, sn, kind, data, needs_null):
@@ -430,6 +470,29 @@ class IrepsGenerator(object):
                 if needs_null:
                     write(b, "null;")
                 write(b, "")
+
+    def follow_irep_single_schema_name(self, b, sn):
+        schema = self.schemata[sn]
+        with indent(b):
+            write(b, "when %s =>" % schema["ada_name"])
+            with indent(b):
+                # the ensuing case analysis may end up doing nothing for some irep kinds
+                # in Ada cases cannot be empty hence we insert null statement if necessary
+                needs_null = True
+
+                # Set all subs
+                subs = self.collect_subs(sn)
+                for i in xrange(len(subs)):
+                    needs_null = self.follow_irep_set_all_subs(b, sn, subs, i, needs_null)
+
+                # Set all namedSub and comments
+                for setter_name in self.named_setters:
+                    needs_null = self.follow_irep_set_all_namedsubs_and_comments(b, sn, setter_name, needs_null)
+
+                if needs_null:
+                    write(b, "null;")
+                write(b, "")
+
 
     def register_schema(self, sn):
         if sn == "source_location":
@@ -1684,8 +1747,24 @@ class IrepsGenerator(object):
         write(s, "--  Serialise to JSON")
         write(s, "")
 
+        write(s, "function Follow_Irep (I : Irep;")
+        with indent(s):
+            write(s, "Follow_Symbol : not null access function (Symbol_I : Irep)")
+        with indent(s):
+            write(s, "return Irep) return Irep;")
+        write(s, "--  Replace Symbol Types")
+        write(s, "")
+
         write(b, "function To_JSON (L : Irep_List) return JSON_Array;")
         write(b, "--  Serialise list to JSON")
+        write(b, "")
+
+        write(b, "function Follow_Irep (L : Irep_List;")
+        with indent(b):
+            write(b, "Follow_Symbol : not null access function (Symbol_I : Irep)")
+        with indent(b):
+            write(b, "return Irep) return Irep_List;")
+        write(b, "--  Replace Symbol Types")
         write(b, "")
 
         write (b, "function Trivial_Irep (S : String_Id) return JSON_Value;")
@@ -1724,6 +1803,13 @@ class IrepsGenerator(object):
         # cnst ::= schema -> id|namedSub|comment -> {name: value}
 
         write(b, "function To_JSON (L : Irep_List) return JSON_Array")
+        write(b, "is separate;")
+        continuation(b)
+        write(b, "")
+
+        write(b, "function Follow_Irep (L : Irep_List;")
+        write(b, "Follow_Symbol : not null access function (Symbol_I : Irep)")
+        write(b, "return Irep) return Irep_List")
         write(b, "is separate;")
         continuation(b)
         write(b, "")
@@ -1838,6 +1924,42 @@ class IrepsGenerator(object):
         write(b, "return V;")
         manual_outdent(b)
         write(b, "end To_JSON;")
+        write(b, "")
+
+        write_comment_block(b, "Follow_Irep")
+        write(b, "function Follow_Irep (I : Irep;")
+        with indent(b):
+            write(b, "Follow_Symbol : not null access function (Symbol_I : Irep)")
+        with indent(b):
+            write(b, "return Irep) return Irep")
+        write(b, "is")
+        write(b, "begin")
+        manual_indent(b)
+        write(b, "if I = 0 then")
+        with indent(b):
+            write(b, "return I;")
+        write(b, "end if;")
+        write(b, "")
+        write(b, "if Kind (I) = I_Symbol_Type then")
+        with indent(b):
+            write(b, "return Follow_Symbol (I);")
+        write(b, "end if;")
+        write(b, "")
+        write(b, "declare")
+        with indent(b):
+            write(b, "N : Irep_Node renames Irep_Table.Table (I);")
+        write(b, "begin")
+        manual_indent(b)
+        write(b, "case N.Kind is")
+
+        for sn in self.top_sorted_sn:
+            self.follow_irep_single_schema_name(b, sn)
+        write(b, "end case;")
+        manual_outdent(b)
+        write(b, "end;")
+        write(b, "return I;")
+        manual_outdent(b)
+        write(b, "end Follow_Irep;")
         write(b, "")
 
         ##########################################################################

--- a/testsuite/gnat2goto/tests/primitive_pointer/test.opt
+++ b/testsuite/gnat2goto/tests/primitive_pointer/test.opt
@@ -1,1 +1,0 @@
-ALL XFAIL gnat2goto fails to compile input (regression)


### PR DESCRIPTION
**REVIEW LAST COMMIT ONLY!**

Based on #83 (not yet merged) and #79 

1. The use of cpp new is replaced here only within the 'Get_Array_Dup_Function' - for early feedback.

2. Setting directly array length in 'Get_Array_Copy_Function' is now reverted as this causes a failure in cbmc when ran on the 'arrays' regression test. That is under investigation.

3. separation markers and alternative implementation and funky alignment -> are not intended as permanent!